### PR TITLE
Use Cloudflare API endpoint instead of raw URL

### DIFF
--- a/sync-security-group-with-cloudflare-ip-addresses.py
+++ b/sync-security-group-with-cloudflare-ip-addresses.py
@@ -55,17 +55,22 @@ class SecurityGroup:
 
     def grab_cloudflare_ipaddresses(self):
         http = urllib3.PoolManager()
-        response = http.request("GET", "https://www.cloudflare.com/ips-v4")
+    
+        response = http.request(
+            "GET",
+            "https://api.cloudflare.com/client/v4/ips"
+        )
+    
         if response.status != 200:
-            raise Exception(f"Failed to fetch IPv4 addresses. HTTP Status Code: {response.status}")
-            
-        self.cloudflare_ip_addresses_v4 = response.data.decode("utf-8").split("\n")
-        http = urllib3.PoolManager()
-        response = http.request("GET", "https://www.cloudflare.com/ips-v6")
-        if response.status != 200:
-            raise Exception(f"Failed to fetch IPv6 addresses. HTTP Status Code: {response.status}")
-            
-        self.cloudflare_ip_addresses_v6 = response.data.decode("utf-8").split("\n")
+            raise Exception(
+                f"Cloudflare API request failed with status {response.status}"
+            )
+    
+        data = json.loads(response.data.decode("utf-8"))
+    
+        self.cloudflare_ip_addresses_v4 = data["result"]["ipv4_cidrs"]
+        self.cloudflare_ip_addresses_v6 = data["result"]["ipv6_cidrs"]
+    
         return
     
     def make_rule_maps(self):


### PR DESCRIPTION
Switching to the API endpoint because of this issue Cloudflare recently had:

<img width="940" height="453" alt="image" src="https://github.com/user-attachments/assets/09f04258-8f09-49ce-8fc8-75e4ff3eb897" />

I realize the API endpoint is much more reliable as compared to hitting the raw URLs. 

Plus with the API endpoint, one call returns both IPv4 and IPv6 addresses in JSON, which is easier to parse. So there's no need to make two separate calls to raw URLs and parse the CIDR ranges manually. 